### PR TITLE
Add login and restrict menu tabs

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -28,6 +28,10 @@ def create_app(config_name):
   migrate = Migrate(app, db)
   from app import models
 
+  # blueprint for auth routes in our app
+  from .auth import auth as auth_blueprint
+  app.register_blueprint(auth_blueprint)
+
   from .home import home as home_blueprint
   app.register_blueprint(home_blueprint)
 

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -34,6 +34,16 @@ def create_app(config_name):
   def load_user(user_id):
     return user.query.get(int(user_id))
 
+  def role_required(role_name):
+    def decorator(func):
+      @wraps(func)
+      def authorize(*args, **kwargs):
+        if not current_user.has_role(role_name):
+          abort(401) # not authorized
+        return func(*args, **kwargs)
+      return authorize
+    return decorator
+
   Bootstrap(app)
   csrf.init_app(app)
   db.init_app(app)

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -6,6 +6,8 @@ from flask_bootstrap import Bootstrap
 from flask_sqlalchemy import SQLAlchemy
 from flask_migrate import Migrate
 
+from flask_login import LoginManager
+
 # local imports
 from config import app_config
 
@@ -20,7 +22,18 @@ def create_app(config_name):
   app = Flask(__name__, instance_relative_config=True)
   app.config.from_object(app_config[config_name])
   #app.config.from_pyfile('config.py')
-  
+
+  # setup for flask_login
+  login_manager = LoginManager()
+  login_manager.login_view = 'auth.login'
+  login_manager.init_app(app)
+
+  from .models import user
+
+  @login_manager.user_loader
+  def load_user(user_id):
+    return user.query.get(int(user_id))
+
   Bootstrap(app)
   csrf.init_app(app)
   db.init_app(app)
@@ -30,6 +43,7 @@ def create_app(config_name):
 
   # blueprint for auth routes in our app
   from .auth import auth as auth_blueprint
+  csrf.exempt(auth_blueprint)
   app.register_blueprint(auth_blueprint)
 
   from .home import home as home_blueprint

--- a/app/auth/__init__.py
+++ b/app/auth/__init__.py
@@ -1,0 +1,5 @@
+from flask import Blueprint
+
+auth = Blueprint('auth', __name__)
+
+from . import views

--- a/app/auth/views.py
+++ b/app/auth/views.py
@@ -1,0 +1,13 @@
+from flask import render_template
+# from . import db
+
+from . import auth
+
+@auth.route('/login', methods=['GET', 'POST'])
+def login():
+  # Render the login template on the / route
+  return render_template('auth/login_template.html', title="Welcome")
+
+@auth.route('/logout')
+def logout():
+    return 'Logout'

--- a/app/auth/views.py
+++ b/app/auth/views.py
@@ -13,19 +13,19 @@ def login():
 def login_post():
   email = request.form.get('email')
   password = request.form.get('password')
-  # remember = True if request.form.get('remember') else False
 
+  # check if user actually exists
   found_user = user.query.filter_by(user_email=email).first()
   
-  # check if user actually exists
+  # NOTE: Current version does not hash password. In an actual implementation,
   # take the user supplied password, hash it, and compare it to the hashed password in database
-  # if not user or not check_password_hash(user.password, password): 
   if not found_user or not found_user.user_password_digest == password: 
     flash('Please check your login details and try again.')
     return redirect(url_for('auth.login')) # if user doesn't exist or password is wrong, reload the page
 
   # if the above check passes, then we know the user has the right credentials
   login_user(found_user)
+
   return redirect(url_for('home.homepage'))
 
 @auth.route('/logout')

--- a/app/auth/views.py
+++ b/app/auth/views.py
@@ -1,13 +1,35 @@
-from flask import render_template
-# from . import db
+from flask import render_template, redirect, url_for, request, flash
+from flask_login import login_user, logout_user, login_required
 
 from . import auth
+from ..models import user
 
-@auth.route('/login', methods=['GET', 'POST'])
+@auth.route('/login')
 def login():
   # Render the login template on the / route
   return render_template('auth/login_template.html', title="Welcome")
 
+@auth.route('/login', methods=['POST'])
+def login_post():
+  email = request.form.get('email')
+  password = request.form.get('password')
+  # remember = True if request.form.get('remember') else False
+
+  found_user = user.query.filter_by(user_email=email).first()
+  
+  # check if user actually exists
+  # take the user supplied password, hash it, and compare it to the hashed password in database
+  # if not user or not check_password_hash(user.password, password): 
+  if not found_user or not found_user.user_password_digest == password: 
+    flash('Please check your login details and try again.')
+    return redirect(url_for('auth.login')) # if user doesn't exist or password is wrong, reload the page
+
+  # if the above check passes, then we know the user has the right credentials
+  login_user(found_user)
+  return redirect(url_for('home.homepage'))
+
 @auth.route('/logout')
+@login_required
 def logout():
-    return 'Logout'
+    logout_user()
+    return redirect(url_for('auth.login'))

--- a/app/classification/views.py
+++ b/app/classification/views.py
@@ -5,6 +5,7 @@ from sqlalchemy.exc import SQLAlchemyError
 import json
 import re
 import numpy
+from flask_login import login_required
 
 from . import classification
 from .forms import ClassificationForm
@@ -21,6 +22,7 @@ from ..models import classification as classificationdbo
   
 
 @classification.route('/classification', methods=['GET', 'POST'])
+@login_required
 def start_new_classification():
   
   domainlist = domaindbo.query.order_by(asc(domaindbo.domain_name)).all()
@@ -123,6 +125,7 @@ def compare_submission(domainlist, geolist, sourcelist, usagelist, identruleslis
 
 
 @classification.route('/classification/submit', methods=['GET', 'POST'])
+@login_required
 def submit_classification():
 
   # Submit a new classification for evaluation
@@ -198,6 +201,7 @@ def submit_classification():
 
 
 @classification.route('/classification/add', methods=['GET', 'POST'])
+@login_required
 def add_classification():
   
   submitobj = request.get_json()

--- a/app/contract_dim/views.py
+++ b/app/contract_dim/views.py
@@ -37,10 +37,10 @@ def list_contracts():
 @contract.route('/contracts/add', methods=['GET', 'POST'])
 @login_required
 def add_contract():
-  # Add a contract to the database
 
   confirm_user_is_admin()
 
+  # Add a contract to the database
   add_contract = True
 
   form = ContractForm()

--- a/app/contract_dim/views.py
+++ b/app/contract_dim/views.py
@@ -8,14 +8,14 @@ from . import contract
 from .forms import ContractForm
 from .. import db
 from ..models import contract_dim as contractdbo
-from ..helpers import check_admin
+from ..helpers import confirm_user_is_admin
   
 
 @contract.route('/contracts', methods=['GET', 'POST'])
 @login_required
 def list_contracts():
 
-  check_admin()
+  confirm_user_is_admin()
   
   # List all contracts
   contractslist = contractdbo.query.order_by(asc(contractdbo.contract_name)).all()
@@ -39,7 +39,7 @@ def list_contracts():
 def add_contract():
   # Add a contract to the database
 
-  check_admin()
+  confirm_user_is_admin()
 
   add_contract = True
 
@@ -72,7 +72,7 @@ def add_contract():
 @login_required
 def edit_contract(id):
 
-  check_admin()
+  confirm_user_is_admin()
 
   # Edit a contract
   add_contract = False
@@ -93,7 +93,7 @@ def edit_contract(id):
 @login_required
 def delete_contract(id):
 
-  check_admin()
+  confirm_user_is_admin()
 
   # Delete a contract from the database
 

--- a/app/contract_dim/views.py
+++ b/app/contract_dim/views.py
@@ -2,15 +2,20 @@ from flask import abort, flash, redirect, render_template, url_for, request
 from flask_paginate import Pagination, get_page_args
 from sqlalchemy import asc
 import json
+from flask_login import login_required
 
 from . import contract
 from .forms import ContractForm
 from .. import db
 from ..models import contract_dim as contractdbo
+from ..helpers import check_admin
   
 
 @contract.route('/contracts', methods=['GET', 'POST'])
+@login_required
 def list_contracts():
+
+  check_admin()
   
   # List all contracts
   contractslist = contractdbo.query.order_by(asc(contractdbo.contract_name)).all()
@@ -30,8 +35,11 @@ def list_contracts():
 
 
 @contract.route('/contracts/add', methods=['GET', 'POST'])
+@login_required
 def add_contract():
   # Add a contract to the database
+
+  check_admin()
 
   add_contract = True
 
@@ -61,7 +69,10 @@ def add_contract():
 
 
 @contract.route('/contracts/edit/<int:id>', methods=['GET', 'POST'])
+@login_required
 def edit_contract(id):
+
+  check_admin()
 
   # Edit a contract
   add_contract = False
@@ -79,7 +90,10 @@ def edit_contract(id):
 
 
 @contract.route('/contracts/delete/<int:id>', methods=['GET', 'POST'])
+@login_required
 def delete_contract(id):
+
+  check_admin()
 
   # Delete a contract from the database
 

--- a/app/control/__init__.py
+++ b/app/control/__init__.py
@@ -1,6 +1,4 @@
 from flask import Blueprint
-from ..helpers import check_admin
-from flask_login import login_required
 
 control = Blueprint('control', __name__)
 

--- a/app/control/__init__.py
+++ b/app/control/__init__.py
@@ -1,4 +1,6 @@
 from flask import Blueprint
+from ..helpers import check_admin
+from flask_login import login_required
 
 control = Blueprint('control', __name__)
 

--- a/app/control/views.py
+++ b/app/control/views.py
@@ -36,10 +36,10 @@ def list_controls():
 @control.route('/controls/add', methods=['GET', 'POST'])
 @login_required
 def add_control():
-  # Add a control to the database
 
   confirm_user_is_admin()
 
+  # Add a control to the database
   add_control = True
 
   form = ControlForm()

--- a/app/control/views.py
+++ b/app/control/views.py
@@ -8,13 +8,13 @@ from . import control
 from .forms import ControlForm
 from .. import db
 from ..models import control as controldbo
-from ..helpers import check_admin
+from ..helpers import confirm_user_is_admin
 
 @control.route('/controls', methods=['GET', 'POST'])
 @login_required
 def list_controls():
   
-  check_admin()
+  confirm_user_is_admin()
   
   # List all controls
   controlslist = controldbo.query.order_by(asc(controldbo.control_name)).all()
@@ -38,7 +38,7 @@ def list_controls():
 def add_control():
   # Add a control to the database
 
-  check_admin()
+  confirm_user_is_admin()
 
   add_control = True
 
@@ -69,7 +69,7 @@ def add_control():
 @login_required
 def edit_control(id):
 
-  check_admin()
+  confirm_user_is_admin()
 
   # Edit a control
   add_control = False
@@ -96,7 +96,7 @@ def edit_control(id):
 @login_required
 def delete_control(id):
 
-  check_admin()
+  confirm_user_is_admin()
 
   # Delete a control from the database
 

--- a/app/control/views.py
+++ b/app/control/views.py
@@ -2,15 +2,19 @@ from flask import abort, flash, redirect, render_template, url_for, request
 from flask_paginate import Pagination, get_page_args
 from sqlalchemy import asc
 import json
+from flask_login import login_required
 
 from . import control
 from .forms import ControlForm
 from .. import db
 from ..models import control as controldbo
-  
+from ..helpers import check_admin
 
 @control.route('/controls', methods=['GET', 'POST'])
+@login_required
 def list_controls():
+  
+  check_admin()
   
   # List all controls
   controlslist = controldbo.query.order_by(asc(controldbo.control_name)).all()
@@ -30,8 +34,11 @@ def list_controls():
 
 
 @control.route('/controls/add', methods=['GET', 'POST'])
+@login_required
 def add_control():
   # Add a control to the database
+
+  check_admin()
 
   add_control = True
 
@@ -59,7 +66,10 @@ def add_control():
 
 
 @control.route('/controls/edit/<int:id>', methods=['GET', 'POST'])
+@login_required
 def edit_control(id):
+
+  check_admin()
 
   # Edit a control
   add_control = False
@@ -83,7 +93,10 @@ def edit_control(id):
 
 
 @control.route('/controls/delete/<int:id>', methods=['GET', 'POST'])
+@login_required
 def delete_control(id):
+
+  check_admin()
 
   # Delete a control from the database
 

--- a/app/control_recipe/views.py
+++ b/app/control_recipe/views.py
@@ -8,14 +8,14 @@ from .. import db
 from ..models import control as controldbo
 from ..models import recipe as recipedbo
 from ..models import control_recipe as controlrecipedbo
-from ..helpers import check_admin
+from ..helpers import confirm_user_is_admin
 
 
 @control_recipe.route('/control_recipes', methods=['GET', 'POST'])
 @login_required
 def list_control_recipes():
   
-  check_admin()
+  confirm_user_is_admin()
   
   # List all recipes
   sql = text("select cr.control_recipe_id, c.control_id, c.control_name, " +
@@ -35,7 +35,7 @@ def list_control_recipes():
 @login_required
 def add_control_recipe(rid, cid):
   
-  check_admin()
+  confirm_user_is_admin()
   
   # Add a control recipe to the database
   
@@ -73,7 +73,7 @@ def add_control_recipe(rid, cid):
 @login_required
 def edit_control_recipe(id):
 
-  check_admin()
+  confirm_user_is_admin()
 
   # Edit a control recipe
   add_control_recipe = False
@@ -103,7 +103,7 @@ def edit_control_recipe(id):
 @login_required
 def delete_control_recipe(id):
 
-  check_admin()
+  confirm_user_is_admin()
 
   # Delete a control recipe from the database
 

--- a/app/control_recipe/views.py
+++ b/app/control_recipe/views.py
@@ -1,5 +1,6 @@
 from flask import abort, flash, redirect, render_template, url_for
 from sqlalchemy import text
+from flask_login import login_required
 
 from . import control_recipe
 from .forms import ControlRecipeForm
@@ -7,10 +8,14 @@ from .. import db
 from ..models import control as controldbo
 from ..models import recipe as recipedbo
 from ..models import control_recipe as controlrecipedbo
+from ..helpers import check_admin
 
 
 @control_recipe.route('/control_recipes', methods=['GET', 'POST'])
+@login_required
 def list_control_recipes():
+  
+  check_admin()
   
   # List all recipes
   sql = text("select cr.control_recipe_id, c.control_id, c.control_name, " +
@@ -27,42 +32,48 @@ def list_control_recipes():
 
 
 @control_recipe.route('/control_recipes/add/<int:rid>/<int:cid>', methods=['GET', 'POST'])
+@login_required
 def add_control_recipe(rid, cid):
-
+  
+  check_admin()
+  
   # Add a control recipe to the database
-
-    add_control_recipe = True
-    
-    form = ControlRecipeForm()
-    """   if form.is_submitted:
-      print("Submitted")
-    if form.validate():
-      print("VALID ONE")
-    print(form.errors)
-    if form.validate_on_submit():
-      print("VALID") """
-    crdata = controlrecipedbo(control_id=cid, #form.control_id.data,
-                              recipe_id=rid) #form.recipe_id.data)
-    try:
-      # add control recipe to the database
-      db.session.add(crdata)
-      db.session.commit()
-      flash('You have successfully added a new control recipe.')
-    except:
-      # in case control recipe id already exists
-      flash('Error: control recipe already exists.')
-    
-    # redirect to controls page
-    return redirect(url_for('control_recipe.list_control_recipes'))
+  
+  add_control_recipe = True
+  
+  form = ControlRecipeForm()
+  """   if form.is_submitted:
+    print("Submitted")
+  if form.validate():
+    print("VALID ONE")
+  print(form.errors)
+  if form.validate_on_submit():
+    print("VALID") """
+  crdata = controlrecipedbo(control_id=cid, #form.control_id.data,
+                            recipe_id=rid) #form.recipe_id.data)
+  try:
+    # add control recipe to the database
+    db.session.add(crdata)
+    db.session.commit()
+    flash('You have successfully added a new control recipe.')
+  except:
+    # in case control recipe id already exists
+    flash('Error: control recipe already exists.')
+  
+  # redirect to controls page
+  return redirect(url_for('control_recipe.list_control_recipes'))
 
   # load control template
-    # return render_template('recipe/recipe_crud.html', action="Add",
-    #                       add_control_recipe=add_control_recipe, form=form,
-    #                       title="Add Control Recipe")
+  # return render_template('recipe/recipe_crud.html', action="Add",
+  #                       add_control_recipe=add_control_recipe, form=form,
+  #                       title="Add Control Recipe")
 
 
 @control_recipe.route('/control_recipes/edit/<int:id>', methods=['GET', 'POST'])
+@login_required
 def edit_control_recipe(id):
+
+  check_admin()
 
   # Edit a control recipe
   add_control_recipe = False
@@ -89,7 +100,10 @@ def edit_control_recipe(id):
 
 
 @control_recipe.route('/control_recipes/delete/<int:id>', methods=['GET', 'POST'])
+@login_required
 def delete_control_recipe(id):
+
+  check_admin()
 
   # Delete a control recipe from the database
 

--- a/app/domain_dim/views.py
+++ b/app/domain_dim/views.py
@@ -2,14 +2,19 @@ from flask import abort, flash, redirect, render_template, url_for, request
 from flask_paginate import Pagination, get_page_args
 from sqlalchemy import asc
 import json
+from flask_login import login_required
 
 from . import domain
 from .forms import DomainForm
 from .. import db
 from ..models import domain_dim as domaindbo
+from ..helpers import check_admin
   
 @domain.route('/domains', methods=['GET', 'POST'])
+@login_required
 def list_domains():
+
+  check_admin()
 
   #List all domains
   domainslist = domaindbo.query.order_by(asc(domaindbo.domain_name)).all()
@@ -27,8 +32,11 @@ def list_domains():
                           title="Domains")
 
 @domain.route('/domains/add', methods=['GET', 'POST'])
+@login_required
 def add_domain():
   # Add a domain to the database
+
+  check_admin()
 
   add_domain = True
 
@@ -61,7 +69,10 @@ def add_domain():
 
 
 @domain.route('/domains/edit/<int:id>', methods=['GET', 'POST'])
+@login_required
 def edit_domain(id):
+
+  check_admin()
 
   print("made it " + str(id))
   # Edit a domain
@@ -83,7 +94,10 @@ def edit_domain(id):
 
 
 @domain.route('/domains/delete/<int:id>', methods=['GET', 'POST'])
+@login_required
 def delete_domain(id):
+
+  check_admin()
 
   # Delete a domain from the database
   print(id)

--- a/app/domain_dim/views.py
+++ b/app/domain_dim/views.py
@@ -8,13 +8,13 @@ from . import domain
 from .forms import DomainForm
 from .. import db
 from ..models import domain_dim as domaindbo
-from ..helpers import check_admin
+from ..helpers import confirm_user_is_admin
   
 @domain.route('/domains', methods=['GET', 'POST'])
 @login_required
 def list_domains():
 
-  check_admin()
+  confirm_user_is_admin()
 
   #List all domains
   domainslist = domaindbo.query.order_by(asc(domaindbo.domain_name)).all()
@@ -36,7 +36,7 @@ def list_domains():
 def add_domain():
   # Add a domain to the database
 
-  check_admin()
+  confirm_user_is_admin()
 
   add_domain = True
 
@@ -72,7 +72,7 @@ def add_domain():
 @login_required
 def edit_domain(id):
 
-  check_admin()
+  confirm_user_is_admin()
 
   print("made it " + str(id))
   # Edit a domain
@@ -97,7 +97,7 @@ def edit_domain(id):
 @login_required
 def delete_domain(id):
 
-  check_admin()
+  confirm_user_is_admin()
 
   # Delete a domain from the database
   print(id)

--- a/app/geography_dim/views.py
+++ b/app/geography_dim/views.py
@@ -2,15 +2,20 @@ from flask import abort, flash, redirect, render_template, url_for, request
 from flask_paginate import Pagination, get_page_args
 from sqlalchemy import asc
 import json
+from flask_login import login_required
 
 from . import geography
 from .forms import GeographyForm
 from .. import db
 from ..models import geography_dim as geographydbo
+from ..helpers import check_admin
   
 
 @geography.route('/geography', methods=['GET', 'POST'])
+@login_required
 def list_geography():
+
+  check_admin()
   
   # List all geography
   geographylist = geographydbo.query.order_by(asc(geographydbo.geo_name)).all()
@@ -30,7 +35,11 @@ def list_geography():
 
 
 @geography.route('/geography/add', methods=['GET', 'POST'])
+@login_required
 def add_geography():
+
+  check_admin()
+
   # Add a geography to the database
 
   add_geography = True
@@ -64,7 +73,10 @@ def add_geography():
 
 
 @geography.route('/geography/edit/<int:id>', methods=['GET', 'POST'])
+@login_required
 def edit_geography(id):
+
+  check_admin()
 
   print("made it " + str(id))
   # Edit a geography
@@ -86,7 +98,10 @@ def edit_geography(id):
 
 
 @geography.route('/geography/delete/<int:id>', methods=['GET', 'POST'])
+@login_required
 def delete_geography(id):
+
+  check_admin()
 
   # Delete a geography from the database
   print(id)

--- a/app/geography_dim/views.py
+++ b/app/geography_dim/views.py
@@ -8,14 +8,14 @@ from . import geography
 from .forms import GeographyForm
 from .. import db
 from ..models import geography_dim as geographydbo
-from ..helpers import check_admin
+from ..helpers import confirm_user_is_admin
   
 
 @geography.route('/geography', methods=['GET', 'POST'])
 @login_required
 def list_geography():
 
-  check_admin()
+  confirm_user_is_admin()
   
   # List all geography
   geographylist = geographydbo.query.order_by(asc(geographydbo.geo_name)).all()
@@ -38,7 +38,7 @@ def list_geography():
 @login_required
 def add_geography():
 
-  check_admin()
+  confirm_user_is_admin()
 
   # Add a geography to the database
 
@@ -76,7 +76,7 @@ def add_geography():
 @login_required
 def edit_geography(id):
 
-  check_admin()
+  confirm_user_is_admin()
 
   print("made it " + str(id))
   # Edit a geography
@@ -101,7 +101,7 @@ def edit_geography(id):
 @login_required
 def delete_geography(id):
 
-  check_admin()
+  confirm_user_is_admin()
 
   # Delete a geography from the database
   print(id)

--- a/app/helpers/__init__.py
+++ b/app/helpers/__init__.py
@@ -1,7 +1,7 @@
 from flask import abort
 from flask_login import current_user
 
-def check_admin():
+def confirm_user_is_admin():
   # prevent non-admins from accessing the page
   if not current_user.user_is_admin:
     abort(403)

--- a/app/helpers/__init__.py
+++ b/app/helpers/__init__.py
@@ -1,0 +1,7 @@
+from flask import abort
+from flask_login import current_user
+
+def check_admin():
+  # prevent non-admins from accessing the page
+  if not current_user.user_is_admin:
+    abort(403)

--- a/app/home/views.py
+++ b/app/home/views.py
@@ -1,14 +1,18 @@
 from flask import abort, flash, redirect, render_template, url_for
+from flask_login import login_required, current_user
+
 from . import home
 
 @home.route('/', methods=['GET', 'POST'])
+@login_required
 def homepage():
   
   # Render the homepage template on the / route
-  return render_template('home/index.html', title="Welcome")
+  return render_template('home/index.html', current_user=current_user, title="Welcome")
 
 
 @home.route('/control/dashboard')
+@login_required
 def control_dashboard():
 
   return render_template("home/control_dashboard.html", title="Control")

--- a/app/home/views.py
+++ b/app/home/views.py
@@ -4,11 +4,12 @@ from flask_login import login_required, current_user
 from . import home
 
 @home.route('/', methods=['GET', 'POST'])
-@login_required
 def homepage():
-  
-  # Render the homepage template on the / route
-  return render_template('home/index.html', current_user=current_user, title="Welcome")
+  if current_user.is_authenticated:
+    # Render the homepage template on the / route
+    return render_template('home/index.html', current_user=current_user, title="Welcome")
+  else:
+    return redirect(url_for('auth.login'))
 
 
 @home.route('/control/dashboard')

--- a/app/identifiability/views.py
+++ b/app/identifiability/views.py
@@ -2,15 +2,20 @@ from flask import abort, flash, redirect, render_template, url_for, request
 from flask_paginate import Pagination, get_page_args
 from sqlalchemy import asc
 import json
+from flask_login import login_required
 
 from . import ident_dim
 from .forms import IdentifiabilityForm
 from .. import db
 from ..models import ident_dim as identdbo
+from ..helpers import check_admin
   
 
 @ident_dim.route('/identifiability', methods=['GET', 'POST'])
+@login_required
 def list_ident_rules():
+
+  check_admin()
   
   # List all ident_dims
   identlist = identdbo.query.order_by(asc(identdbo.rule_id)).all()
@@ -30,7 +35,11 @@ def list_ident_rules():
 
 
 @ident_dim.route('/identifiability/add', methods=['GET', 'POST'])
+@login_required
 def add_ident_dim():
+
+  check_admin()
+
   # Add a ident_dim to the database
 
   add_ident_dim = True
@@ -61,7 +70,10 @@ def add_ident_dim():
 
 
 @ident_dim.route('/identifiability/edit/<int:id>', methods=['GET', 'POST'])
+@login_required
 def edit_ident_dim(id):
+
+  check_admin()
 
   # Edit a ident_dim
   add_ident_dim = False
@@ -81,7 +93,10 @@ def edit_ident_dim(id):
 
 
 @ident_dim.route('/identifiability/delete/<int:id>', methods=['GET', 'POST'])
+@login_required
 def delete_ident_dim(id):
+
+  check_admin()
 
   # Delete a ident_dim from the database
 

--- a/app/identifiability/views.py
+++ b/app/identifiability/views.py
@@ -8,14 +8,14 @@ from . import ident_dim
 from .forms import IdentifiabilityForm
 from .. import db
 from ..models import ident_dim as identdbo
-from ..helpers import check_admin
+from ..helpers import confirm_user_is_admin
   
 
 @ident_dim.route('/identifiability', methods=['GET', 'POST'])
 @login_required
 def list_ident_rules():
 
-  check_admin()
+  confirm_user_is_admin()
   
   # List all ident_dims
   identlist = identdbo.query.order_by(asc(identdbo.rule_id)).all()
@@ -38,7 +38,7 @@ def list_ident_rules():
 @login_required
 def add_ident_dim():
 
-  check_admin()
+  confirm_user_is_admin()
 
   # Add a ident_dim to the database
 
@@ -73,7 +73,7 @@ def add_ident_dim():
 @login_required
 def edit_ident_dim(id):
 
-  check_admin()
+  confirm_user_is_admin()
 
   # Edit a ident_dim
   add_ident_dim = False
@@ -96,7 +96,7 @@ def edit_ident_dim(id):
 @login_required
 def delete_ident_dim(id):
 
-  check_admin()
+  confirm_user_is_admin()
 
   # Delete a ident_dim from the database
 

--- a/app/models.py
+++ b/app/models.py
@@ -24,6 +24,17 @@ class basemodel(db.Model):
             for column, value in self._to_dict().items()
     }
 
+class user(basemodel):
+  __tablename__ = "user"
+  user_id = db.Column(db.Integer, primary_key=True) 
+  user_email = db.Column(db.String(100), unique=True)
+  user_password_digest = db.Column(db.String(100))
+  user_is_admin = db.Column(db.Boolean, default=False)
+
+  def __init__(self, **kwargs):
+    self.user_email = kwargs.get("user_email")
+    self.user_password_digest = kwargs.get("user_password_digest")
+    self.user_is_admin = kwargs.get("user_is_admin")
 
 class control(basemodel):
   __tablename__ = "control"

--- a/app/models.py
+++ b/app/models.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 from app import db
-
+from flask_login import UserMixin
 
 class basemodel(db.Model):
   __abstract__ = True
@@ -24,12 +24,15 @@ class basemodel(db.Model):
             for column, value in self._to_dict().items()
     }
 
-class user(basemodel):
+class user(UserMixin, basemodel):
   __tablename__ = "user"
-  user_id = db.Column(db.Integer, primary_key=True) 
-  user_email = db.Column(db.String(100), unique=True)
-  user_password_digest = db.Column(db.String(100))
-  user_is_admin = db.Column(db.Boolean, default=False)
+  user_id = db.Column(db.Integer, unique=True, nullable=False, primary_key=True) 
+  user_email = db.Column(db.String(100), unique=True, nullable=False)
+  user_password_digest = db.Column(db.String(100), nullable=False)
+  user_is_admin = db.Column(db.Boolean, default=False, nullable=False)
+
+  def get_id(self):
+    return self.user_id
 
   def __init__(self, **kwargs):
     self.user_email = kwargs.get("user_email")

--- a/app/recipe/views.py
+++ b/app/recipe/views.py
@@ -10,14 +10,14 @@ from .. import db
 from ..models import recipe as recipedbo
 from ..models import control as controldbo
 from ..models import control_recipe as controlrecipedbo
-from ..helpers import check_admin
+from ..helpers import confirm_user_is_admin
   
 
 @recipe.route('/recipes', methods=['GET', 'POST'])
 @login_required
 def list_recipes():
 
-  check_admin()
+  confirm_user_is_admin()
   
   # List all recipes
   recipeslist = recipedbo.query.order_by(asc(recipedbo.recipe_name)).all()
@@ -39,7 +39,7 @@ def list_recipes():
 @login_required
 def add_recipe():
 
-  check_admin()
+  confirm_user_is_admin()
 
   # Add a recipe to the database
 
@@ -71,7 +71,7 @@ def add_recipe():
 @login_required
 def edit_recipe(id):
 
-  check_admin()
+  confirm_user_is_admin()
 
   # Edit a department
   add_recipe = False
@@ -92,7 +92,7 @@ def edit_recipe(id):
 @login_required
 def delete_recipe(id):
 
-  check_admin()
+  confirm_user_is_admin()
 
   # Delete a department from the database
 

--- a/app/recipe/views.py
+++ b/app/recipe/views.py
@@ -2,6 +2,7 @@ from flask import abort, flash, redirect, render_template, url_for, request
 from flask_paginate import Pagination, get_page_args
 from sqlalchemy import asc
 import json
+from flask_login import login_required
 
 from . import recipe
 from .forms import RecipeForm
@@ -9,10 +10,14 @@ from .. import db
 from ..models import recipe as recipedbo
 from ..models import control as controldbo
 from ..models import control_recipe as controlrecipedbo
+from ..helpers import check_admin
   
 
 @recipe.route('/recipes', methods=['GET', 'POST'])
+@login_required
 def list_recipes():
+
+  check_admin()
   
   # List all recipes
   recipeslist = recipedbo.query.order_by(asc(recipedbo.recipe_name)).all()
@@ -31,7 +36,11 @@ def list_recipes():
 
 
 @recipe.route('/recipes/add', methods=['GET', 'POST'])
+@login_required
 def add_recipe():
+
+  check_admin()
+
   # Add a recipe to the database
 
   add_recipe = True
@@ -59,7 +68,10 @@ def add_recipe():
   return redirect(url_for('recipe.list_recipes'))
 
 @recipe.route('/recipes/edit/<int:id>', methods=['GET', 'POST'])
+@login_required
 def edit_recipe(id):
+
+  check_admin()
 
   # Edit a department
   add_recipe = False
@@ -77,7 +89,10 @@ def edit_recipe(id):
 
 
 @recipe.route('/recipes/delete/<int:id>', methods=['GET', 'POST'])
+@login_required
 def delete_recipe(id):
+
+  check_admin()
 
   # Delete a department from the database
 

--- a/app/sensitive_fields/views.py
+++ b/app/sensitive_fields/views.py
@@ -2,15 +2,20 @@ from flask import abort, flash, redirect, render_template, url_for, request
 from flask_paginate import Pagination, get_page_args
 from sqlalchemy import asc
 import json
+from flask_login import login_required
 
 from . import sdf_dim
 from .forms import SensitiveFieldsForm
 from .. import db
 from ..models import sdf_dim as sdfdbo
+from ..helpers import check_admin
   
 
 @sdf_dim.route('/sensitive-fields', methods=['GET', 'POST'])
+@login_required
 def list_sensitive_fields():
+
+  check_admin()
   
   # List all sdf_dims
   sdflist = sdfdbo.query.order_by(asc(sdfdbo.sdf_name)).all()
@@ -30,7 +35,11 @@ def list_sensitive_fields():
 
 
 @sdf_dim.route('/sensitive-fields/add', methods=['GET', 'POST'])
+@login_required
 def add_sdf_dim():
+
+  check_admin()
+
   # Add a sdf_dim to the database
 
   add_sdf_dim = True
@@ -61,7 +70,10 @@ def add_sdf_dim():
 
 
 @sdf_dim.route('/sensitive-fields/edit/<int:id>', methods=['GET', 'POST'])
+@login_required
 def edit_sdf_dim(id):
+
+  check_admin()
 
   # Edit a sdf_dim
   add_sdf_dim = False
@@ -83,7 +95,10 @@ def edit_sdf_dim(id):
 
 
 @sdf_dim.route('/sensitive-fields/delete/<int:id>', methods=['GET', 'POST'])
+@login_required
 def delete_sdf_dim(id):
+
+  check_admin()
 
   # Delete a sdf_dim from the database
 

--- a/app/sensitive_fields/views.py
+++ b/app/sensitive_fields/views.py
@@ -8,14 +8,14 @@ from . import sdf_dim
 from .forms import SensitiveFieldsForm
 from .. import db
 from ..models import sdf_dim as sdfdbo
-from ..helpers import check_admin
+from ..helpers import confirm_user_is_admin
   
 
 @sdf_dim.route('/sensitive-fields', methods=['GET', 'POST'])
 @login_required
 def list_sensitive_fields():
 
-  check_admin()
+  confirm_user_is_admin()
   
   # List all sdf_dims
   sdflist = sdfdbo.query.order_by(asc(sdfdbo.sdf_name)).all()
@@ -38,7 +38,7 @@ def list_sensitive_fields():
 @login_required
 def add_sdf_dim():
 
-  check_admin()
+  confirm_user_is_admin()
 
   # Add a sdf_dim to the database
 
@@ -73,7 +73,7 @@ def add_sdf_dim():
 @login_required
 def edit_sdf_dim(id):
 
-  check_admin()
+  confirm_user_is_admin()
 
   # Edit a sdf_dim
   add_sdf_dim = False
@@ -98,7 +98,7 @@ def edit_sdf_dim(id):
 @login_required
 def delete_sdf_dim(id):
 
-  check_admin()
+  confirm_user_is_admin()
 
   # Delete a sdf_dim from the database
 

--- a/app/source_dim/views.py
+++ b/app/source_dim/views.py
@@ -2,15 +2,20 @@ from flask import abort, flash, redirect, render_template, url_for, request
 from flask_paginate import Pagination, get_page_args
 from sqlalchemy import asc
 import json
+from flask_login import login_required
 
 from . import source_dim
 from .forms import SourceForm
 from .. import db
 from ..models import source_dim as sourcedbo
+from ..helpers import check_admin
   
 
 @source_dim.route('/sources', methods=['GET', 'POST'])
+@login_required
 def list_source_dims():
+
+  check_admin()
   
   # List all source_dims
   sourcelist = sourcedbo.query.order_by(asc(sourcedbo.source_name)).all()
@@ -30,7 +35,11 @@ def list_source_dims():
 
 
 @source_dim.route('/sources/add', methods=['GET', 'POST'])
+@login_required
 def add_source_dim():
+
+  check_admin()
+
   # Add a source_dim to the database
 
   add_source_dim = True
@@ -61,7 +70,10 @@ def add_source_dim():
 
 
 @source_dim.route('/sources/edit/<int:id>', methods=['GET', 'POST'])
+@login_required
 def edit_source_dim(id):
+
+  check_admin()
 
   # Edit a source_dim
   add_source_dim = False
@@ -81,7 +93,10 @@ def edit_source_dim(id):
 
 
 @source_dim.route('/sources/delete/<int:id>', methods=['GET', 'POST'])
+@login_required
 def delete_source_dim(id):
+
+  check_admin()
 
   # Delete a source_dim from the database
 

--- a/app/source_dim/views.py
+++ b/app/source_dim/views.py
@@ -8,14 +8,14 @@ from . import source_dim
 from .forms import SourceForm
 from .. import db
 from ..models import source_dim as sourcedbo
-from ..helpers import check_admin
+from ..helpers import confirm_user_is_admin
   
 
 @source_dim.route('/sources', methods=['GET', 'POST'])
 @login_required
 def list_source_dims():
 
-  check_admin()
+  confirm_user_is_admin()
   
   # List all source_dims
   sourcelist = sourcedbo.query.order_by(asc(sourcedbo.source_name)).all()
@@ -38,7 +38,7 @@ def list_source_dims():
 @login_required
 def add_source_dim():
 
-  check_admin()
+  confirm_user_is_admin()
 
   # Add a source_dim to the database
 
@@ -73,7 +73,7 @@ def add_source_dim():
 @login_required
 def edit_source_dim(id):
 
-  check_admin()
+  confirm_user_is_admin()
 
   # Edit a source_dim
   add_source_dim = False
@@ -96,7 +96,7 @@ def edit_source_dim(id):
 @login_required
 def delete_source_dim(id):
 
-  check_admin()
+  confirm_user_is_admin()
 
   # Delete a source_dim from the database
 

--- a/app/templates/auth/login_template.html
+++ b/app/templates/auth/login_template.html
@@ -1,0 +1,22 @@
+{% extends "base.html" %}
+{% block title %}Login{% endblock %}
+{% block body %}
+<div class="container">
+    <div class="row">
+        <form method="POST" action="/login">
+            <div class="form-group">
+              <label for="loginEmail">Email</label>
+              <input type="email" class="form-control" id="loginEmail" placeholder="Email">
+            </div>
+
+            <div class="form-group">
+              <label for="loginPassword">Password</label>
+              <input type="password" class="form-control" id="loginPassword" placeholder="Password">
+            </div>
+
+            <button type="submit" class="btn btn-primary">Login</button>
+        </form>
+    </div>
+</div>
+{% endblock %}
+

--- a/app/templates/auth/login_template.html
+++ b/app/templates/auth/login_template.html
@@ -6,12 +6,12 @@
         <form method="POST" action="/login">
             <div class="form-group">
               <label for="loginEmail">Email</label>
-              <input type="email" class="form-control" id="loginEmail" placeholder="Email">
+              <input type="email" name="email" class="form-control" id="loginEmail" placeholder="Email">
             </div>
 
             <div class="form-group">
               <label for="loginPassword">Password</label>
-              <input type="password" class="form-control" id="loginPassword" placeholder="Password">
+              <input type="password" name="password" class="form-control" id="loginPassword" placeholder="Password">
             </div>
 
             <button type="submit" class="btn btn-primary">Login</button>

--- a/app/templates/auth/login_template.html
+++ b/app/templates/auth/login_template.html
@@ -2,7 +2,8 @@
 {% block title %}Login{% endblock %}
 {% block body %}
 <div class="container">
-    <div class="row">
+    <div class="row justify-content-center">
+      <div class="mt-5">
         <form method="POST" action="/login">
             <div class="form-group">
               <label for="loginEmail">Email</label>
@@ -16,6 +17,7 @@
 
             <button type="submit" class="btn btn-primary">Login</button>
         </form>
+      </div>
     </div>
 </div>
 {% endblock %}

--- a/app/templates/auth/login_template.html
+++ b/app/templates/auth/login_template.html
@@ -5,14 +5,14 @@
     <div class="mt-5">
       <div class="row justify-content-center">
           {% with messages = get_flashed_messages() %}
-            {% if messages %}
-              {% for message in messages %}
-                <div class="alert alert-danger alert-dismissible" role="alert">
-                  <button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button>
-                  {{ message }}
-                </div>
-              {% endfor %}
-            {% endif %}
+              {% if messages %}
+                  {% for message in messages %}
+                      <div class="alert alert-danger alert-dismissible" role="alert">
+                          <button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+                          {{ message }}
+                      </div>
+                  {% endfor %}
+              {% endif %}
           {% endwith %}
       </div>
       <div class="row justify-content-center">

--- a/app/templates/auth/login_template.html
+++ b/app/templates/auth/login_template.html
@@ -2,23 +2,35 @@
 {% block title %}Login{% endblock %}
 {% block body %}
 <div class="container">
-    <div class="row justify-content-center">
-      <div class="mt-5">
-        <form method="POST" action="/login">
-            <div class="form-group">
-              <label for="loginEmail">Email</label>
-              <input type="email" name="email" class="form-control" id="loginEmail" placeholder="Email">
-            </div>
-
-            <div class="form-group">
-              <label for="loginPassword">Password</label>
-              <input type="password" name="password" class="form-control" id="loginPassword" placeholder="Password">
-            </div>
-
-            <button type="submit" class="btn btn-primary">Login</button>
-        </form>
+    <div class="mt-5">
+      <div class="row justify-content-center">
+          {% with messages = get_flashed_messages() %}
+            {% if messages %}
+              {% for message in messages %}
+                <div class="alert alert-danger alert-dismissible" role="alert">
+                  <button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+                  {{ message }}
+                </div>
+              {% endfor %}
+            {% endif %}
+          {% endwith %}
       </div>
-    </div>
+      <div class="row justify-content-center">
+          <form method="POST" action="/login">
+              <div class="form-group">
+                <label for="loginEmail">Email</label>
+                <input type="email" name="email" class="form-control" id="loginEmail" placeholder="Email">
+              </div>
+
+              <div class="form-group">
+                <label for="loginPassword">Password</label>
+                <input type="password" name="password" class="form-control" id="loginPassword" placeholder="Password">
+              </div>
+
+              <button type="submit" class="btn btn-primary">Login</button>
+          </form>
+      </div>
+  </div>
 </div>
 {% endblock %}
 

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -27,10 +27,11 @@
             </button>
             
             <div class="collapse navbar-collapse" id="navbarSupportedContent">
-                <ul class="navbar-nav mr-auto">
+              <ul class="navbar-nav mr-auto">
                 <li class="nav-item active">
                     <a class="nav-link" href="{{ url_for('home.homepage') }}">Home <span class="sr-only">(current)</span></a>
                 </li>
+                {% if current_user.user_is_admin %}
                 <li class="nav-item dropdown">
                     <a class="nav-link dropdown-toggle" href="#" id="navbarDropdown" role="button" 
                         data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">Edit Controls</a>
@@ -58,7 +59,15 @@
                         <a class="dropdown-item" href="{{ url_for('ident_dim.list_ident_rules') }}">Identifiability Rules</a>
                     </div>
                 </li>
-                </ul>
+                {% endif %}
+                {% if current_user.is_authenticated %}
+                <li class="nav-item">
+                    <a href="{{ url_for('auth.logout') }}" class="nav-link">
+                        Logout
+                    </a>
+                </li>
+                {% endif %}
+              </ul>
             </div>
         </nav>
     </div>

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -64,11 +64,18 @@
                 {% endif %}
               </ul>
               {% if current_user.is_authenticated %}
-              <span class="navbar-text">
-                  <a href="{{ url_for('auth.logout') }}" class="nav-link">
-                      Logout
-                  </a>
-              </span>
+                <span class="navbar-text">
+                    <a href="{{ url_for('auth.logout') }}" class="nav-link">
+                        Logout
+                    </a>
+                </span>
+              {% else %}
+                <span class="navbar-text">
+                    <a href="{{ url_for('auth.login') }}" class="nav-link">
+                        Login
+                    </a>
+                </span>
+
               {% endif %}
             </div>
         </nav>

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -60,14 +60,14 @@
                     </div>
                 </li>
                 {% endif %}
-                {% if current_user.is_authenticated %}
-                <li class="nav-item">
-                    <a href="{{ url_for('auth.logout') }}" class="nav-link">
-                        Logout
-                    </a>
-                </li>
-                {% endif %}
               </ul>
+              {% if current_user.is_authenticated %}
+              <span class="navbar-text">
+                  <a href="{{ url_for('auth.logout') }}" class="nav-link">
+                      Logout
+                  </a>
+              </span>
+              {% endif %}
             </div>
         </nav>
     </div>

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -28,9 +28,11 @@
             
             <div class="collapse navbar-collapse" id="navbarSupportedContent">
               <ul class="navbar-nav mr-auto">
+                {% if current_user.is_authenticated %}
                 <li class="nav-item active">
                     <a class="nav-link" href="{{ url_for('home.homepage') }}">Home <span class="sr-only">(current)</span></a>
                 </li>
+                {% endif %}
                 {% if current_user.user_is_admin %}
                 <li class="nav-item dropdown">
                     <a class="nav-link dropdown-toggle" href="#" id="navbarDropdown" role="button" 

--- a/app/usage_dim/views.py
+++ b/app/usage_dim/views.py
@@ -2,15 +2,20 @@ from flask import abort, flash, redirect, render_template, url_for, request
 from flask_paginate import Pagination, get_page_args
 from sqlalchemy import asc
 import json
+from flask_login import login_required
 
 from . import usage
 from .forms import UsageForm
 from .. import db
 from ..models import usage_dim as usagedbo
+from ..helpers import check_admin
   
 
 @usage.route('/usages', methods=['GET', 'POST'])
+@login_required
 def list_usage():
+
+  check_admin()
   
   # List all usages
   usagelist = usagedbo.query.order_by(asc(usagedbo.usage_name)).all()
@@ -30,7 +35,11 @@ def list_usage():
 
 
 @usage.route('/usages/add', methods=['GET', 'POST'])
+@login_required
 def add_usage():
+
+  check_admin()
+
   # Add a usage to the database
 
   add_usage = True
@@ -61,7 +70,10 @@ def add_usage():
 
 
 @usage.route('/usages/edit/<int:id>', methods=['GET', 'POST'])
+@login_required
 def edit_usage(id):
+
+  check_admin()
 
   # Edit a usage
   add_usage = False
@@ -81,7 +93,10 @@ def edit_usage(id):
 
 
 @usage.route('/usages/delete/<int:id>', methods=['GET', 'POST'])
+@login_required
 def delete_usage(id):
+
+  check_admin()
 
   # Delete a usage from the database
 

--- a/app/usage_dim/views.py
+++ b/app/usage_dim/views.py
@@ -8,14 +8,14 @@ from . import usage
 from .forms import UsageForm
 from .. import db
 from ..models import usage_dim as usagedbo
-from ..helpers import check_admin
+from ..helpers import confirm_user_is_admin
   
 
 @usage.route('/usages', methods=['GET', 'POST'])
 @login_required
 def list_usage():
 
-  check_admin()
+  confirm_user_is_admin()
   
   # List all usages
   usagelist = usagedbo.query.order_by(asc(usagedbo.usage_name)).all()
@@ -38,7 +38,7 @@ def list_usage():
 @login_required
 def add_usage():
 
-  check_admin()
+  confirm_user_is_admin()
 
   # Add a usage to the database
 
@@ -73,7 +73,7 @@ def add_usage():
 @login_required
 def edit_usage(id):
 
-  check_admin()
+  confirm_user_is_admin()
 
   # Edit a usage
   add_usage = False
@@ -96,7 +96,7 @@ def edit_usage(id):
 @login_required
 def delete_usage(id):
 
-  check_admin()
+  confirm_user_is_admin()
 
   # Delete a usage from the database
 


### PR DESCRIPTION
NOTE: Will need to import flask_login package for this to work.

NOTE: This implementation doesn't hash passwords before storing them to the DB (it only stores them in plaintext). However, the DB column is named password_digest to indicate that this should be supported in the future (using bcrypt, most likely). I can add password hashing quickly if you'd like, but didn't bother as this is PoC.

There are two users added to the DB to demonstrate the interface for each type of user:

admin@daugherty.com / password
user@daugherty.com / password

Implemented the following changes:

- Add login and logout routes under auth
- Add user class
- Create user table
- Redirect users to login when they aren't signed in
- Protect admin routes in API using confirm_user_is_admin helper method
- Add UI for login form
- Add logout link for signed-in users
- Add error message when login fails
